### PR TITLE
1ケースのみの間違い探し機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,8 @@ dmypy.json
 
 # VSCode settings
 .vscode/*
+
+# resource, intermediate and result directories
+intermediate/*
+resource/*
+result/*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # saizeriya-photo-hunt
-サイゼリヤの間違い探しをAIの力で解くプログラムです。
+
+サイゼリヤの間違い探しを AI ? の力で解くプログラムです。
+
+## 環境構築
+
+### Python のインストール
+
+環境にあわせて適宜行ってください。
+
+### このレポジトリをクローン
+
+公開鍵認証の方
+
+```sh
+git@github.com:YasunoriMATSUOKA/saizeriya-photo-hunt.git
+```
+
+公開鍵認証ではない方
+
+```sh
+git clone https://github.com/YasunoriMATSUOKA/saizeriya-photo-hunt.git
+```
+
+### クローンしてできたディレクトリに移動
+
+```sh
+cd saizeriya-photo-hunt
+```
+
+### モジュールのインストール
+
+OpenCV
+
+```sh
+pip install opencv-python
+```
+
+numpy
+
+```sh
+pip install numpy
+```
+
+## 参考リンク
+
+[https://note.nkmk.me/python-numpy-opencv-image-binarization/](https://note.nkmk.me/python-numpy-opencv-image-binarization/)
+[https://qiita.com/trami/items/e25eb70a59a51ae4f7ba](https://qiita.com/trami/items/e25eb70a59a51ae4f7ba)
+[https://qiita.com/yori1029/items/a0ddd25c9571b28f3e1c](https://qiita.com/yori1029/items/a0ddd25c9571b28f3e1c)
+
+特徴点マッチング、特徴点座標の取得
+[https://qiita.com/hayata-yamamoto/items/d4033e6652c8fe68698b](https://qiita.com/hayata-yamamoto/items/d4033e6652c8fe68698b)

--- a/convert_color_image_file_to_bw_image_file.py
+++ b/convert_color_image_file_to_bw_image_file.py
@@ -1,0 +1,14 @@
+import os
+import cv2
+import numpy as np
+from create_dir import create_dir
+
+
+def convert_color_image_file_to_bw_image_file(color_image_file_path, bw_image_file_path):
+    color_image = cv2.imread(color_image_file_path)
+    gray_image = cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY)
+    threshold_value, bw_image = cv2.threshold(
+        gray_image, 0, 255, cv2.THRESH_OTSU)
+    bw_image_path = os.path.dirname(bw_image_file_path)
+    create_dir(bw_image_path)
+    cv2.imwrite(bw_image_file_path, bw_image)

--- a/convert_color_image_file_to_bw_image_file_with_manual_threshold.py
+++ b/convert_color_image_file_to_bw_image_file_with_manual_threshold.py
@@ -1,0 +1,14 @@
+import os
+import cv2
+import numpy as np
+from create_dir import create_dir
+
+
+def convert_color_image_file_to_bw_image_file_with_manual_threshold(color_image_file_path, bw_image_file_path, manual_threshold):
+    color_image = cv2.imread(color_image_file_path)
+    gray_image = cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY)
+    threshold_value, bw_image = cv2.threshold(
+        gray_image, manual_threshold, 255, cv2.THRESH_BINARY)
+    bw_image_path = os.path.dirname(bw_image_file_path)
+    create_dir(bw_image_path)
+    cv2.imwrite(bw_image_file_path, bw_image)

--- a/create_detect_field_image_files.py
+++ b/create_detect_field_image_files.py
@@ -1,0 +1,5 @@
+from convert_color_image_file_to_bw_image_file_with_manual_threshold import convert_color_image_file_to_bw_image_file_with_manual_threshold
+
+
+def create_detect_field_image_files(url_list):
+    print(url_list)

--- a/create_diff_image_file.py
+++ b/create_diff_image_file.py
@@ -1,0 +1,12 @@
+import os
+import cv2
+from create_dir import create_dir
+
+
+def create_diff_image_file(left_image_file_path, right_image_file_path, diff_image_file_path):
+    left_image = cv2.imread(left_image_file_path)
+    right_image = cv2.imread(right_image_file_path)
+    diff_image = cv2.absdiff(left_image, right_image)
+    diff_image_path = os.path.dirname(diff_image_file_path)
+    create_dir(diff_image_path)
+    cv2.imwrite(diff_image_file_path, diff_image)

--- a/create_result_image_file.py
+++ b/create_result_image_file.py
@@ -1,0 +1,15 @@
+import os
+import cv2
+from create_dir import create_dir
+
+
+def create_result_image_file(diff_image_file_path, mask_image_file_path, result_image_file_path, left_image_file_path, right_image_file_path):
+    diff_image = cv2.imread(diff_image_file_path)
+    mask_image = cv2.imread(mask_image_file_path)
+    result_image = cv2.bitwise_and(diff_image, mask_image)
+    left_image = cv2.imread(left_image_file_path)
+    right_image = cv2.imread(right_image_file_path)
+    result_image = cv2.hconcat([result_image, left_image, right_image])
+    result_image_path = os.path.dirname(result_image_file_path)
+    create_dir(result_image_path)
+    cv2.imwrite(result_image_file_path, result_image)

--- a/crop_image.py
+++ b/crop_image.py
@@ -1,0 +1,11 @@
+import os
+import cv2
+from create_dir import create_dir
+
+
+def crop_image(image_file_path, crop_image_file_path, crop_x_min, crop_x_max, crop_y_min, crop_y_max):
+    image = cv2.imread(image_file_path)
+    crop_image = image[crop_y_min:crop_y_max, crop_x_min:crop_x_max]
+    crop_image_path = os.path.dirname(crop_image_file_path)
+    create_dir(crop_image_path)
+    cv2.imwrite(crop_image_file_path, crop_image)

--- a/denoise_bw_image_file.py
+++ b/denoise_bw_image_file.py
@@ -1,0 +1,16 @@
+import os
+import cv2
+import numpy as np
+from create_dir import create_dir
+
+
+def denoise_bw_image_file(bw_image_with_white_noise_file_path, denoised_bw_image_file_path, kernel_size_1, kernel_size_2):
+    color_image = cv2.imread(bw_image_with_white_noise_file_path)
+    gray_image = cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY)
+    threshold_value, bw_image = cv2.threshold(
+        gray_image, 254, 255, cv2.THRESH_BINARY)
+    kernel = np.ones((kernel_size_1, kernel_size_2), np.uint8)
+    denoised_bw_image = cv2.morphologyEx(bw_image, cv2.MORPH_OPEN, kernel)
+    denoised_bw_image_path = os.path.dirname(denoised_bw_image_file_path)
+    create_dir(denoised_bw_image_path)
+    cv2.imwrite(denoised_bw_image_file_path, denoised_bw_image)

--- a/detect_field_image_x_range.py
+++ b/detect_field_image_x_range.py
@@ -1,0 +1,74 @@
+import cv2
+
+
+def detect_field_image_x_range(detect_field_image_file_path):
+    color_image = cv2.imread(detect_field_image_file_path)
+    gray_image = cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY)
+    bw_image = cv2.threshold(gray_image, 254, 255, cv2.THRESH_BINARY)[1]
+
+    x_left_end_point = 0
+    x_right_end_point = color_image.shape[1]
+    y_top_end_point = 0
+    y_bottom_end_point = color_image.shape[0]
+
+    x_min = None
+    x_max = None
+    size = None
+
+    contours = cv2.findContours(
+        bw_image, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)[0]
+    vertex_cordinate_list = []
+    for index in range(0, len(contours)):
+        vertex_cordinate_data = cv2.boundingRect(contours[index])
+        x_left = vertex_cordinate_data[0]
+        y_top = vertex_cordinate_data[1]
+        x_right = x_left + vertex_cordinate_data[2]
+        y_bottom = y_top + vertex_cordinate_data[3]
+        vertex_cordinate = {
+            "x_left": x_left,
+            "y_top": y_top,
+            "x_right": x_right,
+            "y_bottom": y_bottom
+        }
+        vertex_cordinate_list.append(vertex_cordinate)
+        if x_left == x_left_end_point and y_top == y_top_end_point and y_bottom == y_bottom_end_point:
+            x_min = vertex_cordinate["x_right"] + 1
+        if x_right == x_right_end_point and y_bottom == y_bottom_end_point and y_top == y_top_end_point:
+            x_max = vertex_cordinate["x_left"] - 1
+
+    if (x_max - x_min + 1) % 2 == 0:
+        size = int((x_max - x_min + 1) / 2)
+    elif (x_max - x_min + 1) % 2 == 1:
+        size = int((x_max - x_min) / 2)
+    else:
+        size = None
+
+    left_image_x_min = None
+    left_image_x_max = None
+    left_image_y_top = y_top_end_point
+    left_image_y_bottom = y_bottom_end_point
+    right_image_x_min = None
+    right_image_x_max = None
+    right_image_y_top = y_top_end_point
+    right_image_y_bottom = y_bottom_end_point
+
+    if size is not None:
+        left_image_x_min = x_min
+        left_image_x_max = x_min + size - 1
+        right_image_x_max = x_max
+        right_image_x_min = x_max - size + 1
+
+    field_image_x_range = [
+        left_image_x_min,
+        left_image_x_max,
+        left_image_y_top,
+        left_image_y_bottom,
+        right_image_x_min,
+        right_image_x_max,
+        right_image_y_top,
+        right_image_y_bottom,
+        left_image_x_max - left_image_x_min,
+        right_image_x_max - right_image_x_min
+    ]
+    print(field_image_x_range)
+    return field_image_x_range

--- a/dilate_bw_image_file.py
+++ b/dilate_bw_image_file.py
@@ -1,0 +1,16 @@
+import os
+import cv2
+import numpy as np
+from create_dir import create_dir
+
+
+def dilate_bw_image_file(bw_image_file_path, dilated_bw_image_file_path, kernel_size_1, kernel_size_2, iteration_times):
+    color_image = cv2.imread(bw_image_file_path)
+    gray_image = cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY)
+    threshold_value, bw_image = cv2.threshold(
+        gray_image, 254, 255, cv2.THRESH_BINARY)
+    kernel = np.ones((kernel_size_1, kernel_size_2), np.uint8)
+    dilated_bw_image = cv2.dilate(bw_image, kernel, iterations=iteration_times)
+    dilated_bw_image_path = os.path.dirname(dilated_bw_image_file_path)
+    create_dir(dilated_bw_image_path)
+    cv2.imwrite(dilated_bw_image_file_path, dilated_bw_image)

--- a/download_resource_images.py
+++ b/download_resource_images.py
@@ -10,4 +10,4 @@ def download_resource_images(url_list, dst_path):
         create_dir(dst_dir_path)
         dst_file_path = dst_dir_path + "/saizeriya_photo_hunt_original_image.png"
         download_file(url, dst_file_path)
-        time.sleep(5)
+        # time.sleep(5)

--- a/erose_bw_image_file.py
+++ b/erose_bw_image_file.py
@@ -4,13 +4,13 @@ import numpy as np
 from create_dir import create_dir
 
 
-def erose_bw_image_file(bw_image_file_path, erosed_bw_image_file_path):
+def erose_bw_image_file(bw_image_file_path, erosed_bw_image_file_path, kernel_size_1, kernel_size_2, iteration_times):
     color_image = cv2.imread(bw_image_file_path)
     gray_image = cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY)
     threshold_value, bw_image = cv2.threshold(
         gray_image, 254, 255, cv2.THRESH_BINARY)
-    kernel = np.ones((3, 3), np.unit8)
-    erosed_bw_image = cv2.erode(bw_image, kernel, iterations=1)
+    kernel = np.ones((kernel_size_1, kernel_size_2), np.uint8)
+    erosed_bw_image = cv2.erode(bw_image, kernel, iterations=iteration_times)
     erosed_bw_image_path = os.path.dirname(erosed_bw_image_file_path)
     create_dir(erosed_bw_image_path)
     cv2.imwrite(erosed_bw_image_file_path, erosed_bw_image)

--- a/erose_bw_image_file.py
+++ b/erose_bw_image_file.py
@@ -1,0 +1,16 @@
+import os
+import cv2
+import numpy as np
+from create_dir import create_dir
+
+
+def erose_bw_image_file(bw_image_file_path, erosed_bw_image_file_path):
+    color_image = cv2.imread(bw_image_file_path)
+    gray_image = cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY)
+    threshold_value, bw_image = cv2.threshold(
+        gray_image, 254, 255, cv2.THRESH_BINARY)
+    kernel = np.ones((3, 3), np.unit8)
+    erosed_bw_image = cv2.erode(bw_image, kernel, iterations=1)
+    erosed_bw_image_path = os.path.dirname(erosed_bw_image_file_path)
+    create_dir(erosed_bw_image_path)
+    cv2.imwrite(erosed_bw_image_file_path, erosed_bw_image)

--- a/feature_point_matching.py
+++ b/feature_point_matching.py
@@ -1,0 +1,62 @@
+import os
+import numpy as np
+import cv2
+from create_dir import create_dir
+
+
+def feature_point_matching(left_image_file_path, right_image_file_path, matching_result_image_file_path):
+    left_image = cv2.imread(left_image_file_path)
+    right_image = cv2.imread(right_image_file_path)
+
+    akaze = cv2.AKAZE_create()
+    kp_left, des_left = akaze.detectAndCompute(left_image, None)
+    kp_right, des_right = akaze.detectAndCompute(right_image, None)
+
+    matcher = cv2.BFMatcher()
+    matches = matcher.knnMatch(des_left, des_right, k=2)
+
+    ratio = 0.5
+    good = []
+    queryIdx_list = []
+    trainIdx_list = []
+    for m, n in matches:
+        if m.distance < ratio * n.distance:
+            good.append([m])
+            queryIdx_list.append(m.queryIdx)
+            trainIdx_list.append(m.trainIdx)
+
+    matching_result_image = cv2.drawMatchesKnn(
+        left_image,
+        kp_left,
+        right_image,
+        kp_right,
+        good,
+        None,
+        flags=2
+    )
+
+    matching_result_image_path = os.path.dirname(
+        matching_result_image_file_path
+    )
+    create_dir(matching_result_image_path)
+    cv2.imwrite(matching_result_image_file_path, matching_result_image)
+
+    vector_x_list = []
+    vector_y_list = []
+    for queryIdx, trainIdx in zip(queryIdx_list, trainIdx_list):
+        kp_left_each_data = kp_left[queryIdx].pt
+        kp_right_each_data = kp_right[trainIdx].pt
+        vector_x = kp_right_each_data[0] - kp_left_each_data[0]
+        vector_y = kp_right_each_data[1] - kp_left_each_data[1]
+        vector_x_list.append(kp_right_each_data[0] - kp_left_each_data[0])
+        vector_y_list.append(kp_right_each_data[1] - kp_left_each_data[1])
+
+    avg_vector_x = sum(vector_x_list) / len(vector_x_list)
+    avg_vector_y = sum(vector_y_list) / len(vector_y_list)
+    print(avg_vector_x, avg_vector_y)
+
+    int_avg_vector_x = int(avg_vector_x)
+    int_avg_vector_y = int(avg_vector_y)
+    print(int_avg_vector_x, int_avg_vector_y)
+
+    return [int_avg_vector_x, int_avg_vector_y]

--- a/main.py
+++ b/main.py
@@ -6,6 +6,9 @@ from create_diff_image_file import create_diff_image_file
 from feature_point_matching import feature_point_matching
 from convert_color_image_file_to_bw_image_file import convert_color_image_file_to_bw_image_file
 from erose_bw_image_file import erose_bw_image_file
+from denoise_bw_image_file import denoise_bw_image_file
+from dilate_bw_image_file import dilate_bw_image_file
+from create_result_image_file import create_result_image_file
 
 url_list = [
     "https://www.saizeriya.co.jp/entertainment/images/1710/body.png",
@@ -33,9 +36,13 @@ download_resource_images(url_list, resource_path)
 
 # 間違い探しの画像領域の特定(グレースケール化→二値化→輪郭検出→左右分割領域検出)
 convert_color_image_file_to_bw_image_file_with_manual_threshold(
-    "resource/1710/saizeriya_photo_hunt_original_image.png", "intermediate/1710/saizeriya_photo_hunt_detect_field_image.png", 254)
+    "resource/1710/saizeriya_photo_hunt_original_image.png",
+    "intermediate/1710/010_saizeriya_photo_hunt_detect_field_image.png",
+    254
+)
 detect_field_x = detect_field_image_x_range(
-    "intermediate/1710/saizeriya_photo_hunt_detect_field_image.png")
+    "intermediate/1710/010_saizeriya_photo_hunt_detect_field_image.png"
+)
 
 left_image_x_min = detect_field_x[0]
 left_image_x_max = detect_field_x[1]
@@ -52,52 +59,51 @@ right_image_size = detect_field_x[9]
 # 間違い探しの画像の左側の画像を切り抜き
 crop_image(
     "resource/1710/saizeriya_photo_hunt_original_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_left_image.png",
-    detect_field_x[0],
-    detect_field_x[1],
-    detect_field_x[2],
-    detect_field_x[3]
+    "intermediate/1710/020_saizeriya_photo_hunt_left_image.png",
+    left_image_x_min,
+    left_image_x_max,
+    left_image_y_min,
+    left_image_y_max
 )
 
 # 間違い探しの画像の右側の画像を切り抜き
 crop_image(
     "resource/1710/saizeriya_photo_hunt_original_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_right_image.png",
-    detect_field_x[4],
-    detect_field_x[5],
-    detect_field_x[6],
-    detect_field_x[7]
+    "intermediate/1710/030_saizeriya_photo_hunt_right_image.png",
+    right_image_x_min,
+    right_image_x_max,
+    right_image_y_min,
+    right_image_y_max
 )
 
 # サイズが全く同じ左右画像の差分画像を取得...平行移動のため使い物にならないくらい無駄に差分検出されている
 create_diff_image_file(
-    "intermediate/1710/saizeriya_photo_hunt_left_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_right_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_diff_image.png"
+    "intermediate/1710/020_saizeriya_photo_hunt_left_image.png",
+    "intermediate/1710/030_saizeriya_photo_hunt_right_image.png",
+    "intermediate/1710/040_saizeriya_photo_hunt_diff_image.png"
 )
 
 # 左右画像内の特徴点のマッチングで平行移動量を推定
 translation_vector = feature_point_matching(
-    "intermediate/1710/saizeriya_photo_hunt_left_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_right_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_matching_result_image.png"
+    "intermediate/1710/020_saizeriya_photo_hunt_left_image.png",
+    "intermediate/1710/030_saizeriya_photo_hunt_right_image.png",
+    "intermediate/1710/050_saizeriya_photo_hunt_matching_result_image.png"
 )
 
 # 推定した平行移動量に基づいてクロップ領域を修正
 translation_vector_x = translation_vector[0]
 translation_vector_y = translation_vector[1]
-
 if translation_vector_x < 0:
-    left_image_x_max = left_image_x_max - translation_vector_x
-    right_image_x_min = right_image_x_min + translation_vector_x
-elif translation_vector_x > 0:
     left_image_x_min = left_image_x_min - translation_vector_x
     right_image_x_max = right_image_x_max + translation_vector_x
+elif translation_vector_x > 0:
+    left_image_x_min = left_image_x_min + translation_vector_x
+    right_image_x_max = right_image_x_max - translation_vector_x
 
 # 間違い探しの画像の左側の画像を切り抜き(平行移動量推定を反映)
 crop_image(
     "resource/1710/saizeriya_photo_hunt_original_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_modified_left_image.png",
+    "intermediate/1710/060_saizeriya_photo_hunt_modified_left_image.png",
     left_image_x_min,
     left_image_x_max,
     left_image_y_min,
@@ -107,7 +113,7 @@ crop_image(
 # 間違い探しの画像の右側の画像を切り抜き(平行移動量推定を反映)
 crop_image(
     "resource/1710/saizeriya_photo_hunt_original_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_modified_right_image.png",
+    "intermediate/1710/070_saizeriya_photo_hunt_modified_right_image.png",
     right_image_x_min,
     right_image_x_max,
     right_image_y_min,
@@ -116,19 +122,49 @@ crop_image(
 
 # サイズが全く同じ左右画像の差分画像を取得...平行移動補正済
 create_diff_image_file(
-    "intermediate/1710/saizeriya_photo_hunt_modified_left_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_modified_right_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_modified_diff_image.png"
+    "intermediate/1710/060_saizeriya_photo_hunt_modified_left_image.png",
+    "intermediate/1710/070_saizeriya_photo_hunt_modified_right_image.png",
+    "intermediate/1710/080_saizeriya_photo_hunt_modified_diff_image.png"
 )
 
 # 差分画像を白黒化
 convert_color_image_file_to_bw_image_file(
-    "intermediate/1710/saizeriya_photo_hunt_modified_diff_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_modified_bw_diff_image.png"
+    "intermediate/1710/080_saizeriya_photo_hunt_modified_diff_image.png",
+    "intermediate/1710/090_saizeriya_photo_hunt_modified_bw_diff_image.png"
 )
 
-# 未だバグがあってここから動かない
+# 平行移動の誤差を除去するため、白黒化した差分画像をモルフォロジー変換で収縮
 erose_bw_image_file(
-    "intermediate/1710/saizeriya_photo_hunt_modified_bw_diff_image.png",
-    "intermediate/1710/saizeriya_photo_hunt_mask_bw_diff_image.png",
+    "intermediate/1710/090_saizeriya_photo_hunt_modified_bw_diff_image.png",
+    "intermediate/1710/100_saizeriya_photo_hunt_modified_bw_diff_mask_image_with_noise.png",
+    1,
+    3,
+    2
+)
+
+# 残ったわずかなノイズをモルフォロジー変換のオープニング処理で除去
+denoise_bw_image_file(
+    "intermediate/1710/100_saizeriya_photo_hunt_modified_bw_diff_mask_image_with_noise.png",
+    "intermediate/1710/110_saizeriya_photo_hunt_modified_bw_diff_mask_image.png",
+    2,
+    2
+)
+
+# 誤差・ノイズ除去のため検出領域が狭くなりすぎているのをモルフォロジー変換で膨張
+dilate_bw_image_file(
+    "intermediate/1710/110_saizeriya_photo_hunt_modified_bw_diff_mask_image.png",
+    "intermediate/1710/120_saizeriya_photo_hunt_modified_bw_diff_mask_image_result.png",
+    2,
+    2,
+    10
+)
+
+
+# 間違い箇所のみ切り抜いた結果画像を作成
+create_result_image_file(
+    "intermediate/1710/080_saizeriya_photo_hunt_modified_diff_image.png",
+    "intermediate/1710/120_saizeriya_photo_hunt_modified_bw_diff_mask_image_result.png",
+    "result/1710/saizeriya_photo_hunt_result_image.png",
+    "intermediate/1710/060_saizeriya_photo_hunt_modified_left_image.png",
+    "intermediate/1710/070_saizeriya_photo_hunt_modified_right_image.png"
 )

--- a/main.py
+++ b/main.py
@@ -1,4 +1,11 @@
 from download_resource_images import download_resource_images
+from convert_color_image_file_to_bw_image_file_with_manual_threshold import convert_color_image_file_to_bw_image_file_with_manual_threshold
+from detect_field_image_x_range import detect_field_image_x_range
+from crop_image import crop_image
+from create_diff_image_file import create_diff_image_file
+from feature_point_matching import feature_point_matching
+from convert_color_image_file_to_bw_image_file import convert_color_image_file_to_bw_image_file
+from erose_bw_image_file import erose_bw_image_file
 
 url_list = [
     "https://www.saizeriya.co.jp/entertainment/images/1710/body.png",
@@ -19,4 +26,109 @@ resource_path = "resource"
 intermediate_path = "intermediate"
 result_path = "result"
 
+# 間違い探しのオリジナル画像をサイゼリヤのWebサイトからダウンロード
 download_resource_images(url_list, resource_path)
+
+# 以下はまだ1ケースのみの実装(後で全ケースの再帰的な実行へリファクタリング予定)
+
+# 間違い探しの画像領域の特定(グレースケール化→二値化→輪郭検出→左右分割領域検出)
+convert_color_image_file_to_bw_image_file_with_manual_threshold(
+    "resource/1710/saizeriya_photo_hunt_original_image.png", "intermediate/1710/saizeriya_photo_hunt_detect_field_image.png", 254)
+detect_field_x = detect_field_image_x_range(
+    "intermediate/1710/saizeriya_photo_hunt_detect_field_image.png")
+
+left_image_x_min = detect_field_x[0]
+left_image_x_max = detect_field_x[1]
+left_image_y_min = detect_field_x[2]
+left_image_y_max = detect_field_x[3]
+right_image_x_min = detect_field_x[4]
+right_image_x_max = detect_field_x[5]
+right_image_y_min = detect_field_x[6]
+right_image_y_max = detect_field_x[7]
+
+left_image_size = detect_field_x[8]
+right_image_size = detect_field_x[9]
+
+# 間違い探しの画像の左側の画像を切り抜き
+crop_image(
+    "resource/1710/saizeriya_photo_hunt_original_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_left_image.png",
+    detect_field_x[0],
+    detect_field_x[1],
+    detect_field_x[2],
+    detect_field_x[3]
+)
+
+# 間違い探しの画像の右側の画像を切り抜き
+crop_image(
+    "resource/1710/saizeriya_photo_hunt_original_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_right_image.png",
+    detect_field_x[4],
+    detect_field_x[5],
+    detect_field_x[6],
+    detect_field_x[7]
+)
+
+# サイズが全く同じ左右画像の差分画像を取得...平行移動のため使い物にならないくらい無駄に差分検出されている
+create_diff_image_file(
+    "intermediate/1710/saizeriya_photo_hunt_left_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_right_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_diff_image.png"
+)
+
+# 左右画像内の特徴点のマッチングで平行移動量を推定
+translation_vector = feature_point_matching(
+    "intermediate/1710/saizeriya_photo_hunt_left_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_right_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_matching_result_image.png"
+)
+
+# 推定した平行移動量に基づいてクロップ領域を修正
+translation_vector_x = translation_vector[0]
+translation_vector_y = translation_vector[1]
+
+if translation_vector_x < 0:
+    left_image_x_max = left_image_x_max - translation_vector_x
+    right_image_x_min = right_image_x_min + translation_vector_x
+elif translation_vector_x > 0:
+    left_image_x_min = left_image_x_min - translation_vector_x
+    right_image_x_max = right_image_x_max + translation_vector_x
+
+# 間違い探しの画像の左側の画像を切り抜き(平行移動量推定を反映)
+crop_image(
+    "resource/1710/saizeriya_photo_hunt_original_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_modified_left_image.png",
+    left_image_x_min,
+    left_image_x_max,
+    left_image_y_min,
+    left_image_y_max
+)
+
+# 間違い探しの画像の右側の画像を切り抜き(平行移動量推定を反映)
+crop_image(
+    "resource/1710/saizeriya_photo_hunt_original_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_modified_right_image.png",
+    right_image_x_min,
+    right_image_x_max,
+    right_image_y_min,
+    right_image_y_max
+)
+
+# サイズが全く同じ左右画像の差分画像を取得...平行移動補正済
+create_diff_image_file(
+    "intermediate/1710/saizeriya_photo_hunt_modified_left_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_modified_right_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_modified_diff_image.png"
+)
+
+# 差分画像を白黒化
+convert_color_image_file_to_bw_image_file(
+    "intermediate/1710/saizeriya_photo_hunt_modified_diff_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_modified_bw_diff_image.png"
+)
+
+# 未だバグがあってここから動かない
+erose_bw_image_file(
+    "intermediate/1710/saizeriya_photo_hunt_modified_bw_diff_image.png",
+    "intermediate/1710/saizeriya_photo_hunt_mask_bw_diff_image.png",
+)


### PR DESCRIPTION
以下の大まかな流れでの処理を実装

1. 間違い探しの画像領域の特定
2. 間違い探しの左右画像のそれぞれの切り抜き
3. 左右画像の差分を取得...平行移動誤差のため使い物にならないくらい無駄に差分検出されてしまう
4. 左右画像内の特徴点のマッチングで平行移動量を推定
5. 推定した平行移動量に基づいて切り抜き領域を修正し、左右画像をそれぞれ再度切り抜き
6. 差分画像の取得...このレベルなら誤差はなんとかなりそうな印象
7. 差分画像を白黒化2値化...大津の二値化で閾値は自動設定としており、ここで色の差が小さいものは落ちてしまう課題あり。一旦は閾値の自動設定の便利さを優先してこのまま進める。
8. 平行移動の誤差を除去するため、白黒化した差分画像をモルフォロジー変換で収縮...x方向の誤差が大きいと推測されるため、kernelサイズはx: 3, y: 1とxの方を大きめにしてみた。
9. 残ったわずかなノイズを除去するため、モルフォロジー変換でオープニング処理
10. 誤差・ノイズ除去のため、検出領域が狭くなりすぎたのをモルフォロジー変換で膨張
11. 間違い箇所のみ切り抜いた画像を生成し、左側画像、右側画像と連結し、結果画像を生成
